### PR TITLE
logic for both types of toggle, fixes #16

### DIFF
--- a/script.js
+++ b/script.js
@@ -17,6 +17,24 @@ const STATE_NAME_DICT = {"DC":"District of Columbia", "AL":"Alabama","AK":"Alask
 // global variable to load in unique cities
 let city_data = []
 
+// global variables for the toggles 
+let citiesVisible = true; // True = show cities, False = don't show cities
+let scaleHPI     = false; // True = user selected HPI scale, False = user selected dollar scale
+
+
+d3.select('#toggle-cities').on('click', () => {
+    citiesVisible = !citiesVisible;
+    d3.selectAll('.city').style('display', citiesVisible ? 'block' : 'none');
+    d3.select('#toggle-cities').text(citiesVisible ? 'Hide Cities' : 'Show Cities');
+});
+  
+d3.select('#toggle-scale').on('click', () => {
+    scaleHPI = !scaleHPI;
+    d3.select('#toggle-scale').text(scaleHPI ? 'Scale: HPI' : 'Scale: Dollar');
+    // Add logic here to switch between HPI and dollar value scale, it would be best to have a function call. 
+    // You might have to invoke generateMap() as the map itself will change colors with a diff scale. 
+});
+
 // Initialize the website
 start();
 
@@ -102,7 +120,8 @@ function generateMap(){
                                 .on('mouseover', (event, _d) => d3.select(event.currentTarget).style("fill", "#ffd500"))
                                 .on("mouseout", (event, d) => d3.select(event.currentTarget).style("fill", colorScale(((ANNUAL_STATE_DATA[d.properties.name])[wantedYear])['Average Price'])))
                                 .on("click", stateCard);
-
+                   
+                                
     //adding city points to map
     svg.selectAll('.city')
         .data(city_data)

--- a/styling.css
+++ b/styling.css
@@ -36,3 +36,10 @@ body{
     pointer-events: none;
     z-index: 1000;
 }
+
+.input-div button {
+    margin-left: 10px;
+    padding: 6px 12px;
+    font-size: 0.9rem;
+  }
+  

--- a/website.html
+++ b/website.html
@@ -13,6 +13,8 @@
             <label for="yearBox">Year:</label>
             <input type="number" id="yearBox" class="year-input" min="2000" max="2010" value="2000" readonly>
             <input id = "year" type="range" min="2000" max="2010" value="2000">
+            <button id="toggle-cities">Hide Cities</button>
+            <button id="toggle-scale">Scale: Dollar</button>
         </div>
         <div id="city-info-card" class="info-card" style="display: none;"></div>
     </body>


### PR DESCRIPTION
code for issue #16 

Added both types of toggle, right now they are a button that a user clicks to hide cities and other button to switch between HPI and dollar scale. When the user clicks the button the text in the button changes to reflect what an additional click would change. Decided on a button setup instead of toggle for the cleaner overall look. 

The logic for hiding cities is complete, but logic for changing scales remains to be implemented. I will complete this once Blair finished her logic for dollar value scale. 

Closes #16 

